### PR TITLE
Update packages & whitelist->allowed-list

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
         "scss/dollar-variable-pattern": "^[a-z_]([a-z0-9-]+)?(__([a-z0-9]+-?)+)*(--([a-z0-9]+-?)+)*(__([a-z0-9]+-?)+){0,2}$",
         "scss/percent-placeholder-pattern": "^[a-z_]([a-z0-9-]+)?(__([a-z0-9]+-?)+)*(--([a-z0-9]+-?)+)*(__([a-z0-9]+-?)+){0,2}$",
         "no-duplicate-selectors": [true],
-        "unit-whitelist": [
+        "unit-allowed-list": [
             [
                 "em",
                 "rem",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/frc/stylelint-config-wp#readme",
   "dependencies": {
-    "stylelint-config-standard": "^20.0.0",
-    "stylelint-scss": "^3.14.2"
+    "stylelint-config-standard": "^23.0.0",
+    "stylelint-scss": "^4.0.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frc/stylelint-config-wp",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Stylelint config for frc wp starter theme",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updating packages & the unit-whitelist (which was deprecated in stylelint 13.7.0)